### PR TITLE
增加了对序列化器字段异常的优雅处理

### DIFF
--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -34,4 +34,4 @@ class ITModelSerializer(serializers.ModelSerializer):
                     pass
             raise ValidationError(self.errors)
 
-        return not bool(self._errors)
+        return not self._errors

--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -1,0 +1,37 @@
+from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
+
+from .exception import ValidationException
+from .response import ResponseStatus
+
+
+
+class ITModelSerializer(serializers.ModelSerializer):
+    def is_valid(self, raise_exception=True):
+        """
+        重写了一下，使序列化器验证的字段错误可以优雅地引发第一个报错。
+        :param raise_exception: 是否引发异常
+        """
+        assert hasattr(self, 'initial_data'), (
+            'Cannot call `.is_valid()` as no `data=` keyword argument was '
+            'passed when instantiating the serializer instance.'
+        )
+
+        if not hasattr(self, '_validated_data'):
+            try:
+                self._validated_data = self.run_validation(self.initial_data)
+            except ValidationError as exc:
+                self._validated_data = {}
+                self._errors = exc.detail
+            else:
+                self._errors = {}
+
+        if self._errors and raise_exception:
+            for i in iter(self._errors.values()):
+                try:
+                    raise ValidationException(ResponseStatus[i[0]])
+                except KeyError:
+                    pass
+            raise ValidationError(self.errors)
+
+        return not bool(self._errors)


### PR DESCRIPTION

    对ModelSerializer的is_valid方法进行了重写。因为我是重度序列化器爱好者，
    每次想把序列化器的字段报错和工具的异常处理结合起来都不太优雅，而且大部分时候
    都只需要用到一个报错信息，所以浅浅整了一下。
    @

