### PR TITLE
修复了DEBUG_LEVEL配置后无法生效的bug

### DIFF
--- a/docs/zh/moudles/exception.md
+++ b/docs/zh/moudles/exception.md
@@ -39,3 +39,6 @@ class ArticleView(ViewSetPlus):
         return Response(ResponseStatus.OK, serializer.data)
 ```
 
+## DEBUG_LEVEL
+
+在`settings.py`中配置DEBUG_LEVEL可以出现不同的报错方式，可选项有`default`（默认报错），`console`（简易报错），默认为`console`

--- a/utils/api_view.py
+++ b/utils/api_view.py
@@ -11,6 +11,12 @@ from django.conf import settings
 import traceback
 import re
 
+debug = settings.DEBUG
+try:
+    level = settings.DEBUG_LEVEL
+except:
+    level = 'console'
+
 
 class ViewSetPlus(ViewSet):
     """
@@ -38,17 +44,17 @@ class ViewSetPlus(ViewSet):
         # print(exc)
         # logger.error(exc)
 
-        debug = settings.__dict__.get('DEBUG', False)
         if debug:
-            level = settings.__dict__.get('DEBUG_LEVEL', 'console')
             if level == 'console':
                 # 报错定位不准，放弃了
                 # file = exc.__traceback__.tb_frame.f_globals["__file__"]
                 # line = exc.__traceback__.tb_lineno
-                e = "".join(traceback.format_exception(*(type(exc), exc, exc.__traceback__)))
+                e = "".join(traceback.format_exception(
+                    *(type(exc), exc, exc.__traceback__)))
                 pattern = re.compile(r'File \"(.*)\", line (\d+),')
                 exception = re.findall(pattern, e)[-1]
-                print(f'\033[1;31m[Error] {exc} in file "{exception[0]}" , line {exception[1]}\033[0m')
+                print(
+                    f'\033[1;31m[Error] {exc} in file "{exception[0]}" , line {exception[1]}\033[0m')
             elif level == 'default':
                 # 默认报错
                 traceback.print_exc()


### PR DESCRIPTION
修复了DEBUG_LEVEL配置后无法生效的bug，并将获取配置放在文件外，不用每次都获取，减小开销，并在文档中添加了该功能的描述。